### PR TITLE
some feedback

### DIFF
--- a/instrumentations/elastic.js
+++ b/instrumentations/elastic.js
@@ -1,3 +1,11 @@
-require('elastic-apm-node').start({
-  serviceName: 'cats-service'
+const apm = require('elastic-apm-node').start({
+  serviceName: 'cats-service',
+  metricsInterval: '0s',
+  logLevel: 'off',
+  apiRequestTime: '3s', // XXX for local usage of mockapmserver.js
 });
+
+apm.addFilter((thing) => {
+  console.dir(thing, {depth: 5});
+  return thing;
+})

--- a/instrumentations/otel.js
+++ b/instrumentations/otel.js
@@ -13,11 +13,11 @@ const {
 
 const sdk = new NodeSDK({
   traceExporter: new ConsoleSpanExporter(),
-  metricReader: new PeriodicExportingMetricReader({
-    exporter: new ConsoleMetricExporter(),
-  }),
+  // metricReader: new PeriodicExportingMetricReader({
+  //   exporter: new ConsoleMetricExporter(),
+  // }),
   instrumentations: [getNodeAutoInstrumentations({
-    // To reduce noise in the console sonce we just want
+    // To reduce noise in the console since we just want
     // http and mongodb spans
     "@opentelemetry/instrumentation-fs": {
       enabled: false,

--- a/out/print.js
+++ b/out/print.js
@@ -25,7 +25,8 @@
 const { existsSync, readFileSync } = require('fs');
 const path = require('path');
 
-const OTEL_FILE = path.resolve(path.join(__dirname, './otel.log'));
+// XXX
+const OTEL_FILE = path.resolve(path.join(__dirname, './elastic.log'));
 
 if (existsSync(OTEL_FILE)) {
   const fileContent = readFileSync(OTEL_FILE, { encoding: 'utf-8' });
@@ -46,6 +47,7 @@ if (existsSync(OTEL_FILE)) {
   }
 
   for (const p of parents) {
+    // TODO: accept either OTel or Elastic property names.
     console.log(`trace ${p.traceId.substring(6)}`);
     console.log(`\`- span ${p.id.substring(6)} "${p.name}" (${p.attributes['http.url']} -> ${p.attributes['http.status_code']})`);
     if (children[p.id]) {
@@ -70,7 +72,7 @@ function quoteProps(str, index, arr) {
 
   let res = str.replace(/"/g, '\\"');
   res = res.replace(/'/g, '"');
-  res = res.replace(/([a-z]+): /gi, (m, g) => `"${g}":`);
+  res = res.replace(/([\w_]+): /g, (m, g) => `"${g}":`);
 
   return res;
 }


### PR DESCRIPTION
Commands:

```
docker-compose up -d  # start a MongoDB server to use for testing
node -r ./instrumentations/otel.js server.js | tee out/otel.log
hey -c 10 -q 1 -z 5s http://localhost:3000/create  # concurrent load
node out/print.js  # process the otel.log to show parent/child groupings
docker-compose down
```

- Suggest adding a README.md with the commands to run and annotated example
  output, so a lazy person can just look without running themself.

- "instrumentations/" might be a misleading term.
  Perhaps "./otel-setup.js" and "./elastic-apm-setup.js".
  Or "./apm-setup/otel.js", "./apm-setup/elastic.js".

- Maybe make "out/print.js" take a file argument, so I can have multiple log
  files without having to overwrite. Then the command `node out/print.js out/otel.log`
  might be clearer that it is processing the log file.

- There is a problem trying to analyse `ConsoleMetricExporter` output: it uses
  console.log with limited depth, so you get:
    ```
    {
      descriptor: {
        name: 'db.client.connections.usage',
        type: 'UP_DOWN_COUNTER',
        description: 'The number of connections that are currently in state described by the state attribute.',
        unit: '{connection}',
        valueType: 1
      },
      dataPointType: 3,
      dataPoints: [
        {
          attributes: [Object],
          startTime: [Array],
          endTime: [Array],
          value: 0
        },
        {
          attributes: [Object],
          startTime: [Array],
          endTime: [Array],
          value: 1
        }
      ]
    }
    ```
    and then the out/print.js script fails:
    ```
    % node out/print.js
    undefined:201
          "attributes":[Object],
                        ^

    SyntaxError: Unexpected token O in JSON at position 4963
    ```
    Might want to remove the metrics setup.


Example run for me that shows the context issue:

```
% node -r ./instrumentations/otel.js server.js | tee out/otel.log

% hey -c 10 -q 1 -z 5s http://localhost:3000/create

% node out/print.js | head -40
trace 9b067bf0a26c60b8aaa5eba59f
`- span de68394794 "GET" (http://localhost:3000/create -> 200)
   `- span 2124001051 "mongodb.insert" (mongodb)
   `- span dc8f9c9adc "mongodb.insert" (mongodb)
   `- span 86861aa3a2 "mongodb.insert" (mongodb)
   `- span 51b032dbb0 "mongodb.insert" (mongodb)
   `- span 2d3387677b "mongodb.insert" (mongodb)
   `- span e0b732a92a "mongodb.insert" (mongodb)
trace 71f22831a7248bd3571655f981
`- span 105ccd245f "GET" (http://localhost:3000/create -> 200)
trace 5d9c3f3676d4a7ec871943d6a3
`- span 80ac630300 "GET" (http://localhost:3000/create -> 200)
   `- span 9ff5d58c30 "mongodb.insert" (mongodb)
   `- span 3c142920a5 "mongodb.insert" (mongodb)
   `- span a95c2b82e9 "mongodb.insert" (mongodb)
   `- span 6eb4d9ac24 "mongodb.insert" (mongodb)
trace a6d70b64e83b01c607a7bc5a97
`- span 854cb98455 "GET" (http://localhost:3000/create -> 200)
trace 875e8f412380b10e30ea510068
`- span 2009462f44 "GET" (http://localhost:3000/create -> 200)
trace 8412989261d0a9674747234b0a
`- span 1543df7e93 "GET" (http://localhost:3000/create -> 200)
trace 33581acb11c2cd9b9fde787289
`- span bd85b0dc17 "GET" (http://localhost:3000/create -> 200)
trace 356260ba7f1c2e232c462cd870
`- span b7b5f9ee59 "GET" (http://localhost:3000/create -> 200)
trace 92466c9d8059ecae2b2969706d
`- span 058c6b8db4 "GET" (http://localhost:3000/create -> 200)
trace 175bfe61d27b0b2dd86a52f295
`- span 937e162fdc "GET" (http://localhost:3000/create -> 200)
trace 723cf63f8d5c138fefe41d1109
`- span cc6d758635 "GET" (http://localhost:3000/create -> 200)
   `- span 04ac7d01e4 "mongodb.insert" (mongodb)
   `- span d3bb37adee "mongodb.insert" (mongodb)
trace be8e4db7e4c020112c4e04a800
`- span 6aa417dc56 "GET" (http://localhost:3000/create -> 200)
   `- span ed5481f5c4 "mongodb.insert" (mongodb)
   `- span 56dc6c7a12 "mongodb.insert" (mongodb)
trace 5e33c21babccec3ef5b60c4492
`- span ca63f0b1fc "GET" (http://localhost:3000/create -> 200)
```


# Elastic output

My patch has a quick hack for console.log output of transactions/spans from elastic-apm-node.
I only *started* on the parsing of it -- see the "TODO" in out/print.js.